### PR TITLE
Implement background agent instructions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Execute items from this list. When finished, make sure you check it off. See PLA
 
 ## Repo setup
 - [x] Initialize application supervision entrypoint `Daftka.Application` with empty supervisors (no behavior yet)
-- [ ] Add base types module with opaque types for topic, partition, offset; add `@spec` to public APIs
+- [x] Add base types module with opaque types for topic, partition, offset; add `@spec` to public APIs
 - [ ] Tooling: add Credo, Dialyxir, ExDoc; set up basic configs and Mix aliases
 - [ ] Set up github actions ci
 

--- a/lib/daftka.ex
+++ b/lib/daftka.ex
@@ -12,6 +12,7 @@ defmodule Daftka do
       :world
 
   """
+  @spec hello() :: :world
   def hello do
     :world
   end

--- a/lib/daftka/types.ex
+++ b/lib/daftka/types.ex
@@ -1,0 +1,118 @@
+defmodule Daftka.Types do
+  @moduledoc """
+  Base opaque types and constructors for Daftka domain primitives.
+
+  Exposes strongly-typed wrappers for topics, partitions, and offsets.
+  The underlying representation is intentionally opaque to callers.
+  """
+
+  # Topic
+  defmodule Topic do
+    @moduledoc false
+    @enforce_keys [:value]
+    defstruct [:value]
+  end
+
+  @opaque topic :: %Topic{value: String.t()}
+  @type topic_error :: {:error, :invalid_topic}
+
+  @doc """
+  Construct a topic.
+
+  Rules:
+  - Non-empty UTF-8 binary
+  - Trimmed value must be non-empty
+  """
+  @spec new_topic(term()) :: {:ok, topic} | topic_error
+  def new_topic(value) when is_binary(value) do
+    trimmed = String.trim(value)
+
+    if trimmed == "" do
+      {:error, :invalid_topic}
+    else
+      {:ok, %Topic{value: trimmed}}
+    end
+  end
+
+  def new_topic(_), do: {:error, :invalid_topic}
+
+  @doc """
+  Extract the underlying topic name.
+  """
+  @spec topic_value(topic) :: String.t()
+  def topic_value(%Topic{value: value}), do: value
+
+  # Partition
+  defmodule Partition do
+    @moduledoc false
+    @enforce_keys [:value]
+    defstruct [:value]
+  end
+
+  @opaque partition :: %Partition{value: non_neg_integer()}
+  @type partition_error :: {:error, :invalid_partition}
+
+  @doc """
+  Construct a partition index (0-based).
+  """
+  @spec new_partition(term()) :: {:ok, partition} | partition_error
+  def new_partition(value) when is_integer(value) and value >= 0 do
+    {:ok, %Partition{value: value}}
+  end
+
+  def new_partition(_), do: {:error, :invalid_partition}
+
+  @doc """
+  Extract the underlying partition index.
+  """
+  @spec partition_value(partition) :: non_neg_integer()
+  def partition_value(%Partition{value: value}), do: value
+
+  # Offset
+  defmodule Offset do
+    @moduledoc false
+    @enforce_keys [:value]
+    defstruct [:value]
+  end
+
+  @opaque offset :: %Offset{value: non_neg_integer()}
+  @type offset_error :: {:error, :invalid_offset}
+
+  @doc """
+  Construct an offset (monotonic, 0-based).
+  """
+  @spec new_offset(term()) :: {:ok, offset} | offset_error
+  def new_offset(value) when is_integer(value) and value >= 0 do
+    {:ok, %Offset{value: value}}
+  end
+
+  def new_offset(_), do: {:error, :invalid_offset}
+
+  @doc """
+  Extract the underlying offset value.
+  """
+  @spec offset_value(offset) :: non_neg_integer()
+  def offset_value(%Offset{value: value}), do: value
+
+  # Predicates
+  @doc """
+  Returns true if the term is a `t:topic/0`.
+  """
+  @spec topic?(term()) :: boolean()
+  def topic?(%Topic{}), do: true
+  def topic?(_), do: false
+
+  @doc """
+  Returns true if the term is a `t:partition/0`.
+  """
+  @spec partition?(term()) :: boolean()
+  def partition?(%Partition{}), do: true
+  def partition?(_), do: false
+
+  @doc """
+  Returns true if the term is a `t:offset/0`.
+  """
+  @spec offset?(term()) :: boolean()
+  def offset?(%Offset{}), do: true
+  def offset?(_), do: false
+end

--- a/test/daftka_types_test.exs
+++ b/test/daftka_types_test.exs
@@ -1,0 +1,45 @@
+defmodule Daftka.TypesTest do
+  use ExUnit.Case, async: true
+
+  alias Daftka.Types
+
+  describe "topic" do
+    test "new_topic trims and validates" do
+      assert {:ok, t} = Types.new_topic("  foo  ")
+      assert Types.topic_value(t) == "foo"
+      assert Types.topic?(t)
+
+      assert {:error, :invalid_topic} = Types.new_topic(123)
+      assert {:error, :invalid_topic} = Types.new_topic("")
+      assert {:error, :invalid_topic} = Types.new_topic("   ")
+    end
+  end
+
+  describe "partition" do
+    test "new_partition validates non-neg integer" do
+      assert {:ok, p} = Types.new_partition(0)
+      assert Types.partition_value(p) == 0
+      assert Types.partition?(p)
+
+      assert {:ok, p2} = Types.new_partition(10)
+      assert Types.partition_value(p2) == 10
+
+      assert {:error, :invalid_partition} = Types.new_partition(-1)
+      assert {:error, :invalid_partition} = Types.new_partition("0")
+    end
+  end
+
+  describe "offset" do
+    test "new_offset validates non-neg integer" do
+      assert {:ok, o} = Types.new_offset(0)
+      assert Types.offset_value(o) == 0
+      assert Types.offset?(o)
+
+      assert {:ok, o2} = Types.new_offset(42)
+      assert Types.offset_value(o2) == 42
+
+      assert {:error, :invalid_offset} = Types.new_offset(-1)
+      assert {:error, :invalid_offset} = Types.new_offset("1")
+    end
+  end
+end


### PR DESCRIPTION
Add `Daftka.Types` module with opaque types for topic, partition, and offset, and annotate `Daftka.hello/0` with `@spec`, fulfilling a `TODO.md` item.

---
<a href="https://cursor.com/background-agent?bcId=bc-5355bf4b-757e-413b-9cc6-1f0181717356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5355bf4b-757e-413b-9cc6-1f0181717356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

