### PR TITLE
Implement rebalancer mvp

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ Execute items from this list. When finished, make sure you check it off. See PLA
 - [x] implement the Metadata Store as a simple in memory kv agent
 - [X] implement the Storage module as a simple in memory log-storage agent (list of Messages (offset, key, value, headers; make a struct for this in Types))
 - [ ] implement the Partition Group as a genserver wrapper around its storage actor. it wont actually be a group, but will really be more similar to a Partition Replica Server.
-- [ ] implement the Rebalancer as a simple metadata store poller that spawns partition groups
+- [x] implement the Rebalancer as a simple metadata store poller that spawns partition groups
 - [ ] implement the Metadata api server
 - [ ] implement the request router
 - [ ] implement the http api gateway

--- a/lib/daftka/partition_replica/server.ex
+++ b/lib/daftka/partition_replica/server.ex
@@ -9,8 +9,10 @@ defmodule Daftka.PartitionReplica.Server do
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
+    case Keyword.get(opts, :name) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
   end
 
   @impl true

--- a/lib/daftka/rebalancer.ex
+++ b/lib/daftka/rebalancer.ex
@@ -1,11 +1,25 @@
 defmodule Daftka.Rebalancer do
   @moduledoc """
-  Rebalancer singleton process (skeleton).
+  Rebalancer singleton process (MVP).
 
-  Will monitor metadata and manage partition replica placement.
+  Periodically polls the metadata store and ensures that for every topic
+  there is a running partition group for partition 0 (single-partition MVP),
+  owned by this node. The owner is recorded in the metadata store.
   """
 
   use GenServer
+
+  alias Daftka.Metadata.Store
+  alias Daftka.Partitions.Supervisor, as: PartitionsSupervisor
+  alias Daftka.Types
+
+  @typedoc """
+  Internal state for the rebalancer process.
+  """
+  @opaque state :: %{timer_ref: reference() | nil, tick_ms: non_neg_integer()}
+
+  @default_tick_ms 50
+  @default_partitions 1
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
@@ -13,7 +27,95 @@ defmodule Daftka.Rebalancer do
   end
 
   @impl true
-  def init(_opts) do
-    {:ok, %{}}
+  @spec init(keyword()) :: {:ok, state}
+  def init(opts) do
+    tick_ms = Keyword.get(opts, :tick_ms, @default_tick_ms)
+    state = %{timer_ref: nil, tick_ms: tick_ms}
+    {:ok, schedule_tick(state, 0)}
+  end
+
+  @impl true
+  def handle_info(:tick, %{tick_ms: tick_ms} = state) do
+    ensure_assignments()
+    {:noreply, schedule_tick(state, tick_ms)}
+  end
+
+  # ---- Internal helpers ----
+
+  defp schedule_tick(state, timeout_ms) do
+    ref = Process.send_after(self(), :tick, timeout_ms)
+    %{state | timer_ref: ref}
+  end
+
+  defp ensure_assignments do
+    topics = Store.list_topics()
+
+    Enum.each(topics, fn {typed_topic, _meta} ->
+      topic_name = Types.topic_value(typed_topic)
+      ensure_topic_assignments(typed_topic, topic_name)
+    end)
+  end
+
+  defp ensure_topic_assignments(typed_topic, topic_name) do
+    # MVP: 1 partition, 1 replica
+    Enum.each(0..(@default_partitions - 1), fn partition_index ->
+      {:ok, typed_partition} = Types.new_partition(partition_index)
+
+      desired_supervisor_pid = ensure_partition_replica_started(topic_name, partition_index, 0)
+
+      case Store.get_partition_owner(typed_topic, typed_partition) do
+        {:ok, current_owner} ->
+          via_pid = partition_replica_supervisor_via_pid(topic_name, partition_index, 0)
+
+          cond do
+            is_pid(current_owner) and Process.alive?(current_owner) and current_owner == via_pid ->
+              :ok
+
+            true ->
+              # Owner missing, dead, or out-of-date: set to the supervisor pid we ensured
+              :ok =
+                Store.set_partition_owner(typed_topic, typed_partition, desired_supervisor_pid)
+          end
+
+        {:error, _} ->
+          :ok = Store.set_partition_owner(typed_topic, typed_partition, desired_supervisor_pid)
+      end
+    end)
+  end
+
+  defp ensure_partition_replica_started(topic_name, partition_index, replica_index) do
+    via = partition_replica_supervisor_via(topic_name, partition_index, replica_index)
+
+    case GenServer.whereis(via) do
+      nil ->
+        case PartitionsSupervisor.start_partition_replica_supervisor(
+               {topic_name, partition_index, replica_index}
+             ) do
+          {:ok, pid} ->
+            pid
+
+          {:error, {:already_started, pid}} ->
+            pid
+
+          {:error, _} ->
+            # If start fails for any reason, attempt to resolve via name (may have raced)
+            partition_replica_supervisor_via_pid(topic_name, partition_index, replica_index)
+        end
+
+      pid when is_pid(pid) ->
+        pid
+    end
+  end
+
+  defp partition_replica_supervisor_via(topic_name, partition_index, replica_index) do
+    {:via, Registry,
+     {Daftka.Registry,
+      {:partition_replica_supervisor, topic_name, partition_index, replica_index}}}
+  end
+
+  defp partition_replica_supervisor_via_pid(topic_name, partition_index, replica_index) do
+    GenServer.whereis(
+      partition_replica_supervisor_via(topic_name, partition_index, replica_index)
+    )
   end
 end

--- a/test/daftka_rebalancer_test.exs
+++ b/test/daftka_rebalancer_test.exs
@@ -1,0 +1,83 @@
+defmodule DaftkaRebalancerTest do
+  use ExUnit.Case, async: false
+
+  alias Daftka.Metadata.Store
+  alias Daftka.Types
+
+  setup do
+    assert Process.whereis(Daftka.Rebalancer)
+    assert Process.whereis(Daftka.Partitions.Supervisor)
+    assert Process.whereis(Store)
+    Store.clear()
+    :ok
+  end
+
+  defp eventually(fun, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, 1_500)
+    interval = Keyword.get(opts, :interval, 25)
+
+    start = System.monotonic_time(:millisecond)
+
+    do_eventually(fun, start, timeout, interval)
+  end
+
+  defp do_eventually(fun, start, timeout, interval) do
+    case fun.() do
+      {:ok, value} ->
+        value
+
+      value when value not in [nil, false] ->
+        value
+
+      _ ->
+        now = System.monotonic_time(:millisecond)
+
+        if now - start > timeout do
+          flunk("eventually/2 timed out after #{timeout} ms")
+        else
+          Process.sleep(interval)
+          do_eventually(fun, start, timeout, interval)
+        end
+    end
+  end
+
+  test "rebalancer spawns partition replica supervisor and sets owner for new topic" do
+    {:ok, topic} = Types.new_topic("rebalance-topic-1")
+    {:ok, p0} = Types.new_partition(0)
+
+    :ok = Store.create_topic(topic)
+
+    via =
+      {:via, Registry,
+       {Daftka.Registry, {:partition_replica_supervisor, "rebalance-topic-1", 0, 0}}}
+
+    pid = eventually(fn -> GenServer.whereis(via) end)
+    assert is_pid(pid) and Process.alive?(pid)
+
+    assert {:ok, ^pid} = Store.get_partition_owner(topic, p0)
+  end
+
+  test "rebalancer recreates supervisor and updates owner if supervisor stops" do
+    {:ok, topic} = Types.new_topic("rebalance-topic-2")
+    {:ok, p0} = Types.new_partition(0)
+
+    :ok = Store.create_topic(topic)
+
+    via =
+      {:via, Registry,
+       {Daftka.Registry, {:partition_replica_supervisor, "rebalance-topic-2", 0, 0}}}
+
+    old_pid = eventually(fn -> GenServer.whereis(via) end)
+    assert {:ok, ^old_pid} = Store.get_partition_owner(topic, p0)
+
+    # Stop the child; DynamicSupervisor will not auto-restart on manual terminate
+    :ok = DynamicSupervisor.terminate_child(Daftka.Partitions.Supervisor, old_pid)
+    eventually(fn -> if GenServer.whereis(via) == nil, do: true, else: nil end)
+
+    # Rebalancer should start it again
+    new_pid = eventually(fn -> GenServer.whereis(via) end)
+    assert is_pid(new_pid) and new_pid != old_pid
+
+    assert {:ok, ^new_pid} = Store.get_partition_owner(topic, p0)
+  end
+end


### PR DESCRIPTION
Implement the Rebalancer MVP to manage partition replica ownership and lifecycle.

The Rebalancer periodically polls the metadata store to ensure that for each topic, partition 0 has an active replica supervisor. It records the supervisor's PID as the owner in the metadata store and restarts supervisors if they terminate, ensuring high availability for partition 0.

---
<a href="https://cursor.com/background-agent?bcId=bc-42a19ec5-452b-406f-a53a-ce9f35408adf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-42a19ec5-452b-406f-a53a-ce9f35408adf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

