### PR TITLE
Implement partition group mvp

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Execute items from this list. When finished, make sure you check it off. See PLA
 - [x] add skeletons for everything listed in the Component Overview in PLAN.md. they should all be registered normally and be genservers or actors as appropriate, but with no functionality.
 - [x] implement the Metadata Store as a simple in memory kv agent
 - [X] implement the Storage module as a simple in memory log-storage agent (list of Messages (offset, key, value, headers; make a struct for this in Types))
-- [ ] implement the Partition Group as a genserver wrapper around its storage actor. it wont actually be a group, but will really be more similar to a Partition Replica Server.
+- [x] implement the Partition Group as a genserver wrapper around its storage actor. it wont actually be a group, but will really be more similar to a Partition Replica Server.
 - [ ] implement the Rebalancer as a simple metadata store poller that spawns partition groups
 - [ ] implement the Metadata api server
 - [ ] implement the request router

--- a/lib/daftka/partition_replica/server.ex
+++ b/lib/daftka/partition_replica/server.ex
@@ -1,20 +1,72 @@
 defmodule Daftka.PartitionReplica.Server do
   @moduledoc """
-  Partition replica server (skeleton).
+  Partition Group MVP: thin GenServer wrapper over the storage actor.
 
-  Will handle add/get and coordinate with storage.
+  Exposes append/fetch and high-watermark operations, delegating to
+  `Daftka.PartitionReplica.Storage`.
   """
 
   use GenServer
 
+  alias Daftka.PartitionReplica.Storage
+  alias Daftka.Types
+
+  @opaque state :: %{storage: GenServer.server()}
+
+  # Client API
+
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
+    storage = Keyword.get(opts, :storage, Storage)
+    GenServer.start_link(__MODULE__, %{storage: storage}, name: name)
+  end
+
+  @doc """
+  Append a message to this partition replica via the underlying storage.
+  Returns `{:ok, offset}` or an error tuple from storage.
+  """
+  @spec append(GenServer.server(), binary(), binary(), Types.headers()) ::
+          {:ok, Types.offset()} | {:error, term()}
+  def append(server \\ __MODULE__, key, value, headers \\ %{}) do
+    GenServer.call(server, {:append, key, value, headers})
+  end
+
+  @doc """
+  Fetch up to `max_count` messages starting from `from_offset` (inclusive).
+  Delegates to storage.
+  """
+  @spec fetch_from(GenServer.server(), Types.offset(), pos_integer()) ::
+          {:ok, [Types.message()]} | {:error, term()}
+  def fetch_from(server \\ __MODULE__, from_offset, max_count) do
+    GenServer.call(server, {:fetch_from, from_offset, max_count})
+  end
+
+  @doc """
+  Return the current high-water mark (next offset) for this partition.
+  """
+  @spec next_offset(GenServer.server()) :: Types.offset()
+  def next_offset(server \\ __MODULE__) do
+    GenServer.call(server, :next_offset)
+  end
+
+  # Server callbacks
+
+  @impl true
+  def init(%{storage: storage}) do
+    {:ok, %{storage: storage}}
   end
 
   @impl true
-  def init(_opts) do
-    {:ok, %{}}
+  def handle_call(:next_offset, _from, %{storage: storage} = state) do
+    {:reply, Storage.next_offset(storage), state}
+  end
+
+  def handle_call({:append, key, value, headers}, _from, %{storage: storage} = state) do
+    {:reply, Storage.append(storage, key, value, headers), state}
+  end
+
+  def handle_call({:fetch_from, from_offset, max_count}, _from, %{storage: storage} = state) do
+    {:reply, Storage.fetch_from(storage, from_offset, max_count), state}
   end
 end

--- a/lib/daftka/partition_replica/supervisor.ex
+++ b/lib/daftka/partition_replica/supervisor.ex
@@ -7,6 +7,10 @@ defmodule Daftka.PartitionReplica.Supervisor do
 
   use Supervisor
 
+  @type topic :: String.t()
+  @type partition :: non_neg_integer()
+  @type replica :: non_neg_integer()
+
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts) do
     name = via_name(opts)
@@ -24,21 +28,40 @@ defmodule Daftka.PartitionReplica.Supervisor do
 
   @impl true
   def init(opts) do
-    _topic = Keyword.fetch!(opts, :topic)
-    _partition = Keyword.fetch!(opts, :partition)
-    _replica = Keyword.fetch!(opts, :replica)
+    topic = Keyword.fetch!(opts, :topic)
+    partition = Keyword.fetch!(opts, :partition)
+    replica = Keyword.fetch!(opts, :replica)
+
+    storage_via = storage_name(topic, partition, replica)
+    server_via = server_name(topic, partition, replica)
 
     children = [
       # Raft runtime (placeholder)
       # Daftka.PartitionReplica.Raft,
 
       # Storage process (placeholder)
-      Daftka.PartitionReplica.Storage,
+      {Daftka.PartitionReplica.Storage, [name: storage_via]},
 
       # Server (placeholder)
-      Daftka.PartitionReplica.Server
+      {Daftka.PartitionReplica.Server, [name: server_via, storage: storage_via]}
     ]
 
     Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  @doc """
+  Resolve the via name for a partition replica's storage process.
+  """
+  @spec storage_name(topic(), partition(), replica()) :: GenServer.name()
+  def storage_name(topic, partition, replica) do
+    {:via, Registry, {Daftka.Registry, {:partition_replica_storage, topic, partition, replica}}}
+  end
+
+  @doc """
+  Resolve the via name for a partition replica's server process.
+  """
+  @spec server_name(topic(), partition(), replica()) :: GenServer.name()
+  def server_name(topic, partition, replica) do
+    {:via, Registry, {Daftka.Registry, {:partition_replica_server, topic, partition, replica}}}
   end
 end

--- a/test/daftka_partition_group_test.exs
+++ b/test/daftka_partition_group_test.exs
@@ -1,0 +1,80 @@
+defmodule DaftkaPartitionGroupTest do
+  use ExUnit.Case, async: false
+
+  alias Daftka.PartitionReplica.Server, as: PartitionGroup
+  alias Daftka.PartitionReplica.Supervisor, as: ReplicaSup
+  alias Daftka.Partitions.Supervisor, as: Partitions
+  alias Daftka.Types
+
+  setup do
+    id = {"topic-g", 0, 0}
+    {:ok, pid} = Partitions.start_partition_replica_supervisor(id)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        :ok = DynamicSupervisor.terminate_child(Partitions, pid)
+      end
+    end)
+
+    {:ok, %{id: id, pid: pid}}
+  end
+
+  test "server and storage are registered via Registry", %{id: {topic, part, rep}} do
+    server_via = ReplicaSup.server_name(topic, part, rep)
+    storage_via = ReplicaSup.storage_name(topic, part, rep)
+
+    assert is_pid(GenServer.whereis(server_via))
+    assert is_pid(GenServer.whereis(storage_via))
+  end
+
+  test "next_offset proxies storage and append advances it", %{id: {topic, part, rep}} do
+    server_via = ReplicaSup.server_name(topic, part, rep)
+
+    o0 = PartitionGroup.next_offset(server_via)
+    assert Types.offset_value(o0) == 0
+
+    assert {:ok, o1} = PartitionGroup.append(server_via, "k1", "v1", %{"h" => "1"})
+    assert Types.offset_value(o1) == 0
+
+    o2 = PartitionGroup.next_offset(server_via)
+    assert Types.offset_value(o2) == 1
+  end
+
+  test "fetch_from returns messages from storage", %{id: {topic, part, rep}} do
+    server_via = ReplicaSup.server_name(topic, part, rep)
+
+    assert {:ok, _} = PartitionGroup.append(server_via, "k1", "v1", %{"x" => "a"})
+    assert {:ok, _} = PartitionGroup.append(server_via, "k2", "v2", %{"y" => "b"})
+    assert {:ok, _} = PartitionGroup.append(server_via, "k3", "v3", %{"z" => "c"})
+
+    {:ok, from1} = Types.new_offset(1)
+    assert {:ok, msgs} = PartitionGroup.fetch_from(server_via, from1, 2)
+    assert length(msgs) == 2
+
+    [m1, m2] = msgs
+    assert Types.message_key(m1) == "k2"
+    assert Types.message_value(m1) == "v2"
+    assert Types.offset_value(Types.message_offset(m1)) == 1
+    assert Types.message_headers(m1) == %{"y" => "b"}
+
+    assert Types.message_key(m2) == "k3"
+    assert Types.offset_value(Types.message_offset(m2)) == 2
+  end
+
+  test "invalid append args propagate error", %{id: {topic, part, rep}} do
+    server_via = ReplicaSup.server_name(topic, part, rep)
+
+    assert {:error, :invalid_append_args} = PartitionGroup.append(server_via, :bad, "v", %{})
+    assert {:error, :invalid_append_args} = PartitionGroup.append(server_via, "k", 1, %{})
+    assert {:error, :invalid_append_args} = PartitionGroup.append(server_via, "k", "v", :bad)
+  end
+
+  test "invalid fetch args propagate error", %{id: {topic, part, rep}} do
+    server_via = ReplicaSup.server_name(topic, part, rep)
+
+    assert {:error, :invalid_fetch_args} = PartitionGroup.fetch_from(server_via, :bad, 10)
+
+    {:ok, o0} = Types.new_offset(0)
+    assert {:error, :invalid_fetch_args} = PartitionGroup.fetch_from(server_via, o0, 0)
+  end
+end


### PR DESCRIPTION
Implement the Partition Group MVP by creating `Daftka.PartitionReplica.Server` to wrap storage and integrating it into the supervisor.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e7bd1aa-2146-4aa9-ad0d-9c7b661692d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e7bd1aa-2146-4aa9-ad0d-9c7b661692d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

