### PR TITLE
Remove duplicate gha ci code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,23 +33,8 @@ jobs:
       - name: Install deps
         run: mix deps.get
 
-      - name: Format check
-        run: mix format --check-formatted
-
-      - name: Compile (warnings as errors)
-        run: mix compile --warnings-as-errors
-
-      - name: Credo
-        run: mix credo --strict
-
       - name: Create PLT directory
         run: mkdir -p priv/plts
 
-      - name: Dialyzer
-        run: mix dialyzer
-
-      - name: Tests
-        run: mix test
-
-      - name: Docs
-        run: MIX_ENV=dev mix docs
+      - name: Run CI (format, compile, credo, dialyzer, tests, docs)
+        run: mix ci

--- a/lib/daftka/gateway/server.ex
+++ b/lib/daftka/gateway/server.ex
@@ -8,9 +8,9 @@ defmodule Daftka.Gateway.Server do
   use Plug.Router
   use Plug.ErrorHandler
 
+  alias Daftka.Metadata.Store
   alias Daftka.Router
   alias Daftka.Types
-  alias Daftka.Metadata.Store
 
   plug(Plug.Logger)
   plug(:match)
@@ -46,11 +46,9 @@ defmodule Daftka.Gateway.Server do
         :ok -> json(conn, 201, %{ok: true})
         {:error, :topic_exists} -> json(conn, 409, %{error: "topic_exists"})
         {:error, :invalid_partitions} -> json(conn, 400, %{error: "invalid_partitions"})
-        {:error, :invalid_topic} -> json(conn, 400, %{error: "invalid_topic"})
       end
     else
       {:error, :invalid_topic} -> json(conn, 400, %{error: "invalid_topic"})
-      _ -> json(conn, 400, %{error: "invalid_body"})
     end
   end
 


### PR DESCRIPTION
Refactor `ci.yml` to use the `mix ci` alias to remove duplication and fix a Dialyzer complaint in `Daftka.Gateway.Server`.

The Dialyzer complaint was resolved by removing an unreachable `{:error, :invalid_topic}` match within a `case` statement and narrowing an overly broad `_` match in a `with ... else` block.

---
<a href="https://cursor.com/background-agent?bcId=bc-33de93b7-1bd1-4aed-8fd6-5baa568cc9c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33de93b7-1bd1-4aed-8fd6-5baa568cc9c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

